### PR TITLE
add batcheble and schedulable for closing old positions

### DIFF
--- a/force-app/main/default/classes/CloseOldPositionScheduler.cls
+++ b/force-app/main/default/classes/CloseOldPositionScheduler.cls
@@ -1,0 +1,6 @@
+public class CloseOldPositionScheduler implements Schedulable {
+  public void execute(SchedulableContext ctx) {
+    CloseOldPositionsBatchble batch = new CloseOldPositionsBatchble();
+    Database.executeBatch(batch);
+  }
+}

--- a/force-app/main/default/classes/CloseOldPositionScheduler.cls-meta.xml
+++ b/force-app/main/default/classes/CloseOldPositionScheduler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CloseOldPositionSchedulerTest.cls
+++ b/force-app/main/default/classes/CloseOldPositionSchedulerTest.cls
@@ -1,0 +1,43 @@
+@isTest
+private class CloseOldPositionSchedulerTest {
+  @isTest
+  static void testScheduler() {
+    Test.startTest();
+
+    Position__c position = TestDataFactory.createPosition('Test');
+    insert position;
+
+    Id jobId = System.schedule(
+      'testScheduler',
+      '0 0 0 * * ?',
+      new CloseOldPositionScheduler()
+    );
+
+    CronTrigger ct = [
+      SELECT Id, CronExpression, TimesTriggered, NextFireTime
+      FROM CronTrigger
+      WHERE id = :jobId
+    ];
+
+    Assert.areEqual(
+      '0 0 0 * * ?',
+      ct.CronExpression,
+      'The CronExpressions are not the same, get: ' + ct.CronExpression
+    );
+
+    Assert.areEqual(0, ct.TimesTriggered, 'The job is running!');
+    Assert.areEqual(
+      '2024-04-23 00:00:00',
+      String.valueOf(ct.NextFireTime),
+      'The expected next time the job will did not meet, instead get: ' +
+      String.valueOf(ct.NextFireTime)
+    );
+    Test.stopTest();
+
+    Assert.areEqual(
+      'Test',
+      [SELECT Id, Title__c FROM Position__c WHERE Id = :position.Id].Title__c,
+      'The expected result is Test'
+    );
+  }
+}

--- a/force-app/main/default/classes/CloseOldPositionSchedulerTest.cls-meta.xml
+++ b/force-app/main/default/classes/CloseOldPositionSchedulerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CloseOldPositionsBatchableTest.cls
+++ b/force-app/main/default/classes/CloseOldPositionsBatchableTest.cls
@@ -1,0 +1,34 @@
+@isTest
+private class CloseOldPositionsBatchableTest {
+  @TestSetup
+  static void makePositions() {
+    Test.startTest();
+    List<Position__c> positions = new List<Position__c>();
+    for (Integer i = 0; i < 200; i++) {
+      Position__c position = TestDataFactory.createPosition('Test');
+      position.Open_Date__c = Date.today().addDays(-100);
+      position.Status__c = 'Open';
+      positions.add(position);
+    }
+    insert positions;
+    Test.stopTest();
+  }
+
+  @isTest
+  static void testCloseOldPositionsBatchble() {
+    Test.startTest();
+    CloseOldPositionsBatchble closeOldPositions = new CloseOldPositionsBatchble();
+    Id batchID = Database.executeBatch(closeOldPositions, 200);
+    Test.stopTest();
+
+    Assert.areEqual(
+      200,
+      [
+        SELECT COUNT()
+        FROM Position__c
+        WHERE Title__c = 'Test' AND Status__c = 'Closed'
+      ],
+      'Batcheble does not work'
+    );
+  }
+}

--- a/force-app/main/default/classes/CloseOldPositionsBatchableTest.cls-meta.xml
+++ b/force-app/main/default/classes/CloseOldPositionsBatchableTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CloseOldPositionsBatchble.cls
+++ b/force-app/main/default/classes/CloseOldPositionsBatchble.cls
@@ -1,0 +1,16 @@
+public class CloseOldPositionsBatchble implements Database.Batchable<SObject> {
+  private static final Date TODAY_MINUS_3_MOUNTH = Date.today().addDays(-90);
+
+  public Database.QueryLocator start(Database.BatchableContext bc) {
+    return Database.getQueryLocator(
+      'SELECT Id, Status__c, Open_Date__c FROM Position__c WHERE Status__c = \'Open\' AND Open_Date__c <= :TODAY_MINUS_3_MOUNTH'
+    );
+  }
+
+  public void execute(Database.BatchableContext bc, List<Position__c> scope) {
+    CloseOldPositionsBatchbleHelper.closeOldPositions(scope);
+  }
+
+  public void finish(Database.BatchableContext bc) {
+  }
+}

--- a/force-app/main/default/classes/CloseOldPositionsBatchble.cls
+++ b/force-app/main/default/classes/CloseOldPositionsBatchble.cls
@@ -1,9 +1,10 @@
 public class CloseOldPositionsBatchble implements Database.Batchable<SObject> {
-  private static final Date TODAY_MINUS_3_MOUNTH = Date.today().addDays(-90);
+  private static final Date TODAY_MINUS_3_MONTHS = Date.today().addDays(-90);
+  private static final String OPEN_STATUS = 'Open';
 
   public Database.QueryLocator start(Database.BatchableContext bc) {
     return Database.getQueryLocator(
-      'SELECT Id, Status__c, Open_Date__c FROM Position__c WHERE Status__c = \'Open\' AND Open_Date__c <= :TODAY_MINUS_3_MOUNTH'
+      'SELECT Id, Status__c, Open_Date__c FROM Position__c WHERE Status__c = :OPEN_STATUS AND Open_Date__c <= :TODAY_MINUS_3_MONTHS'
     );
   }
 

--- a/force-app/main/default/classes/CloseOldPositionsBatchble.cls-meta.xml
+++ b/force-app/main/default/classes/CloseOldPositionsBatchble.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CloseOldPositionsBatchbleHelper.cls
+++ b/force-app/main/default/classes/CloseOldPositionsBatchbleHelper.cls
@@ -1,0 +1,12 @@
+public with sharing class CloseOldPositionsBatchbleHelper {
+  public static void closeOldPositions(List<Position__c> positions) {
+    List<Position__c> closedPositions = new List<Position__c>();
+    for (Position__c position : positions) {
+      position.Status__c = 'Closed';
+      closedPositions.add(position);
+    }
+    if (!closedPositions.isEmpty()) {
+      update closedPositions;
+    }
+  }
+}

--- a/force-app/main/default/classes/CloseOldPositionsBatchbleHelper.cls-meta.xml
+++ b/force-app/main/default/classes/CloseOldPositionsBatchbleHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Task 14 Asynchronous Apex

Create an automatic update of items that have been open for more than 90 days on a daily
basis. Please note that the number of positions to be updated may exceed 10,000 records.
Accordingly, cover the entire code with tests